### PR TITLE
Update Coffea version to 2024.4.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -14,7 +14,7 @@ env:
   GITHUB_REF: ${{ github.ref }}
   # Update each time there is added latest python: it will be used for `latest` tag
   python_latest: "3.11"
-  release: 2024.3.0
+  release: 2024.4.0
   releasev0: 0.7.22
 
 jobs:

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -46,7 +46,7 @@ dependencies:
   - pytorch
   - torch-scatter
   - pip
-  - coffea=2024.3.0
+  - coffea=2024.4.0
   - rucio-clients
   - pip:
     - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2024.4.0`.