### PR TITLE
Pin setuptools<71 for coffea 0.7.x

### DIFF
--- a/coffea-base/Dockerfile.almalinux8
+++ b/coffea-base/Dockerfile.almalinux8
@@ -8,9 +8,9 @@ ENV PYTHON_VERSION=${python}
 RUN yum -y install epel-release \
      && yum -y update \
      && yum -y install curl git bzip2 libgfortran which zsh emacs vim htop man man-pages \
-     && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
-     && bash /tmp/mambaforge.sh -bfp /usr/local \
-     && rm -rf /tmp/mambaforge.sh \
+     && curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+     && bash Miniforge3.sh -bfp /usr/local \
+     && rm -rf Miniforge3.sh \
      && mamba update mamba \
      && mamba clean --all --yes \
      && rpm -e --nodeps curl bzip2 \

--- a/coffea-base/Dockerfile.almalinux9
+++ b/coffea-base/Dockerfile.almalinux9
@@ -8,9 +8,9 @@ ENV PYTHON_VERSION=${python}
 RUN yum -y install epel-release \
      && yum -y update \
      && yum -y --allowerasing install wget git bzip2 libgfortran which zsh emacs vim htop man man-pages \
-     && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
-     && bash /tmp/mambaforge.sh -bfp /usr/local \
-     && rm -rf /tmp/mambaforge.sh \
+     && curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+     && bash Miniforge3.sh -bfp /usr/local \
+     && rm -rf Miniforge3.sh \
      && mamba update mamba \
      && mamba clean --all --yes \
      && yum clean all

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -57,6 +57,7 @@ dependencies:
   - pytorch-sparse
   - pytorch-spline-conv
   - pip:
+    - "setuptools<71"
     - fastjet==3.4.0.1 # LAST VERSION workking with awkward1
     - tritonclient[all]
     - tflite-runtime==2.14.0

--- a/coffea-dask/Dockerfile.almalinux8
+++ b/coffea-dask/Dockerfile.almalinux8
@@ -8,9 +8,9 @@ ENV PYTHON_VERSION=${python}
 RUN yum -y install epel-release \
      && yum -y update \
      && yum -y install wget git bzip2 libgfortran which zsh emacs vim htop man man-pages \
-     && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
-     && bash /tmp/mambaforge.sh -bfp /usr/local \
-     && rm -rf /tmp/mambaforge.sh \
+     && curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+     && bash Miniforge3.sh -bfp /usr/local \
+     && rm -rf Miniforge3.sh \
      && mamba update mamba \
      && mamba clean --all --yes \
      && rpm -e --nodeps curl bzip2 \

--- a/coffea-dask/Dockerfile.almalinux9
+++ b/coffea-dask/Dockerfile.almalinux9
@@ -8,9 +8,9 @@ ENV PYTHON_VERSION=${python}
 RUN yum -y install epel-release \
      && yum -y update \
      && yum -y --allowerasing install wget git bzip2 libgfortran which zsh emacs vim htop man man-pages \
-     && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
-     && bash /tmp/mambaforge.sh -bfp /usr/local \
-     && rm -rf /tmp/mambaforge.sh \
+     && curl -fsSLo Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+     && bash Miniforge3.sh -bfp /usr/local \
+     && rm -rf Miniforge3.sh \
      #&& conda config --set solver classic \
      && mamba update mamba \
      && mamba clean --all --yes \


### PR DESCRIPTION
Fixes broken tests from PR #32:
```
2024-09-24 12:10:40,298 - distributed.worker - ERROR - Compute Failed
Key:       MyProcessor-b3328515488d1f102eb8845099c03df1
State:     executing
Function:  MyProcessor
args:      ((WorkItem(dataset='dimuon', filename='https://github.com/CoffeaTeam/coffea/raw/master/tests/samples/nano_dimuon.root', treename='Events', entrystart=0, entrystop=40, fileuuid=b'\xa2\x10\xa3\xf86H\x11\xea\xa2\x9f\xf5\xb5\\\x90\xbe\xef', usermeta={}), b'\x04"M\x18h@-\x00\x00\x00\x00\x00\x00\x00v,\x00\x00\x00R\x80\x05\x95"\x00\x01\x00\xf0\x13\x8c\x0btest_dimuon\x94\x8c\x0bMyProcessor\x94\x93\x94)\x81\x94.\x00\x00\x00\x00'))
kwargs:    {}
Exception: 'AttributeError("module \'setuptools\' has no attribute \'extern\'")'
```
and the same issue which was reported https://github.com/scikit-hep/uproot5/issues/1259