### PR TITLE
New coffea 0.7.23

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -15,7 +15,7 @@ env:
   # Update each time there is added latest python: it will be used for `latest` tag
   python_latest: "3.11"
   release: "2024.11.0"
-  releasev0: "0.7.22"
+  releasev0: "0.7.23"
 
 jobs:
 

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -18,6 +18,8 @@ dependencies:
   - dask-gateway
   - dask-jobqueue
   - dask-expr
+   # To be reverted: Dask needs to be pinned for now, do not use dask>=2024.12.0 with coffea, dask-awkward, or uproot
+  - dask=2024.11.2
   - bokeh
   # Add workqueue
   - ndcctools

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -58,7 +58,7 @@ dependencies:
   - pytorch-sparse
   - pytorch-spline-conv
   - pip:
-    - coffea=0.7.23
+    - coffea==0.7.23
     - "setuptools<71"
     - fastjet==3.4.0.1 # LAST VERSION workking with awkward1
     - tritonclient[all]

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -43,7 +43,6 @@ dependencies:
   - correctionlib
   - python-graphviz
     # scikit-hep
-  - awkward<2
   - vector
   - hist
     # ML
@@ -59,8 +58,9 @@ dependencies:
   - pytorch-spline-conv
   - pip:
     - coffea==0.7.23
+    - awkward==1.10.5
     - "setuptools<71"
-    - fastjet==3.4.0.1 # LAST VERSION workking with awkward1
+    - fastjet==3.4.0.1 # LAST VERSION working with awkward1
     - tritonclient[all]
     - tflite-runtime==2.14.0
     - onnxruntime

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -49,7 +49,6 @@ dependencies:
   - pytorch
   - torch-scatter
   - pip
-  - coffea=0.7.22
   - rucio-clients
     # pyg
   - pyg
@@ -57,6 +56,7 @@ dependencies:
   - pytorch-sparse
   - pytorch-spline-conv
   - pip:
+    - coffea=0.7.23
     - "setuptools<71"
     - fastjet==3.4.0.1 # LAST VERSION workking with awkward1
     - tritonclient[all]

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -19,6 +19,8 @@ dependencies:
   - dask_labextension
   - dask-gateway
   - dask-jobqueue
+  # To be reverted: Dask needs to be pinned for now, do not use dask>=2024.12.0 with coffea, dask-awkward, or uproot
+  - dask=2024.11.2
   - bokeh
   # Add workqueue
   - ndcctools


### PR DESCRIPTION
CI doesnt pick new 0.7.x version from pip, so we will update manually

Fixes: https://github.com/CoffeaTeam/af-images/issues/43