### PR TITLE
Update Coffea version to 2025.1.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -16,7 +16,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2024.11.0"
+  release: "2025.1.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually
   releasev0: "0.7.23"
 

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -55,7 +55,7 @@ dependencies:
   - pytorch
   - torch-scatter
   - pip
-  - coffea=2024.11.0
+  - coffea=2025.1.0
   - rucio-clients
     # pyg
   - pyg


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.1.0`.