### PR TITLE
Check for new Coffea versions daily instead of hourly

### DIFF
--- a/.github/workflows/watch-conda.yaml
+++ b/.github/workflows/watch-conda.yaml
@@ -3,7 +3,7 @@ name: Check for new versions of Coffea on Conda Forge
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
 
 
 jobs:


### PR DESCRIPTION
Checking for new versions on conda-forge hourly is unnecessary and also clogs up the "Actions" page. Change it to daily 