### PR TITLE
Update Coffea version to 2025.3.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2025.1.1"
+  release: "2025.3.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.26"
 

--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -53,7 +53,7 @@ dependencies:
   - pytorch
   ##- torch-scatter  # no aarch64 support
   - pip
-  - coffea=2025.1.1
+  - coffea=2025.3.0
   - rucio-clients
     # pyg
   ##- pyg # no aarch64 support

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,7 +47,7 @@ dependencies:
   - vector
   - hist
   - pip
-  - coffea=2025.1.1
+  - coffea=2025.3.0
   - rucio-clients
   - pip:
     - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -53,7 +53,7 @@ dependencies:
   - pytorch
   - torch-scatter
   - pip
-  - coffea=2025.1.1
+  - coffea=2025.3.0
   - rucio-clients
     # pyg
   - pyg


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.3.0`.

Fixes: https://github.com/CoffeaTeam/af-images/issues/73