### PR TITLE
Fixing broken voms-proxy init with conda package voms

### DIFF
--- a/coffea-base/Dockerfile.almalinux8
+++ b/coffea-base/Dockerfile.almalinux8
@@ -33,4 +33,5 @@ RUN if [ "${TARGETPLATFORM}" == "linux/arm64" ]; then \
 RUN ln -s /usr/local/etc/grid-security /etc/grid-security && \
     curl -L https://github.com/opensciencegrid/osg-vo-config/archive/refs/heads/master.tar.gz | \
     tar -xz --strip-components=1 --directory=/etc/grid-security --wildcards */vomses */vomsdir && \
-    mv /etc/grid-security/vomses /etc
+    cp /etc/grid-security/vomses /etc && \
+    mv /etc/grid-security/vomses /usr/local/etc/

--- a/coffea-base/Dockerfile.almalinux9
+++ b/coffea-base/Dockerfile.almalinux9
@@ -32,4 +32,5 @@ RUN if [ "${TARGETPLATFORM}" == "linux/arm64" ]; then \
 RUN ln -s /usr/local/etc/grid-security /etc/grid-security && \
     curl -L https://github.com/opensciencegrid/osg-vo-config/archive/refs/heads/master.tar.gz | \
     tar -xz --strip-components=1 --directory=/etc/grid-security --wildcards */vomses */vomsdir && \
-    mv /etc/grid-security/vomses /etc
+    cp /etc/grid-security/vomses /etc && \
+    mv /etc/grid-security/vomses /usr/local/etc/

--- a/coffea-dask/Dockerfile.almalinux8
+++ b/coffea-dask/Dockerfile.almalinux8
@@ -33,4 +33,5 @@ RUN if [ "${TARGETPLATFORM}" == "linux/arm64" ]; then \
 RUN ln -s /usr/local/etc/grid-security /etc/grid-security && \
     curl -L https://github.com/opensciencegrid/osg-vo-config/archive/refs/heads/master.tar.gz | \
     tar -xz --strip-components=1 --directory=/etc/grid-security --wildcards */vomses */vomsdir && \
-    mv /etc/grid-security/vomses /etc
+    cp /etc/grid-security/vomses /etc && \
+    mv /etc/grid-security/vomses /usr/local/etc/

--- a/coffea-dask/Dockerfile.almalinux9
+++ b/coffea-dask/Dockerfile.almalinux9
@@ -33,4 +33,5 @@ RUN if [ "${TARGETPLATFORM}" == "linux/arm64" ]; then \
 RUN ln -s /usr/local/etc/grid-security /etc/grid-security && \
     curl -L https://github.com/opensciencegrid/osg-vo-config/archive/refs/heads/master.tar.gz | \
     tar -xz --strip-components=1 --directory=/etc/grid-security --wildcards */vomses */vomsdir && \
-    mv /etc/grid-security/vomses /etc
+    cp /etc/grid-security/vomses /etc && \
+    mv /etc/grid-security/vomses /usr/local/etc/

--- a/coffea-dask/Dockerfile.almalinux9-noml
+++ b/coffea-dask/Dockerfile.almalinux9-noml
@@ -28,4 +28,5 @@ RUN mamba install --yes python=${PYTHON_VERSION} \
 RUN ln -s /usr/local/etc/grid-security /etc/grid-security && \
     curl -L https://github.com/opensciencegrid/osg-vo-config/archive/refs/heads/master.tar.gz | \
     tar -xz --strip-components=1 --directory=/etc/grid-security --wildcards */vomses */vomsdir && \
-    mv /etc/grid-security/vomses /etc
+    cp /etc/grid-security/vomses /etc && \
+    mv /etc/grid-security/vomses /usr/local/etc/


### PR DESCRIPTION
Fixes: https://github.com/CoffeaTeam/coffea-casa/issues/408 and https://github.com/CoffeaTeam/coffea-casa/issues/335
```
[cms-jovyan@jupyter-oksana-2eshadura-40cern-2ech ~]$ voms-proxy-init --voms cms --debug
Unspecified proxy version, settling on version 4 (RFC)
PCI extension info: 
 Path length: -1
 Policy language not specified.
 Policy file not specified.
Number of bits in key :2048
Files being used:
 CA certificate file: none
 Trusted certificates directory : /etc/grid-security/certificates
 Proxy certificate file : /tmp/x509up_u6440
 User certificate file: /home/cms-jovyan/.globus/usercert.pem
 User key file: /home/cms-jovyan/.globus/userkey.pem
Output to /tmp/x509up_u6440
Enter GRID pass phrase:
Your identity: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=oshadura/CN=728983/CN=Oksana Shadura
error:12000079:random number generator::Cannot open file:crypto/rand/randfile.c:106Filename=/home/cms-jovyan/.rnd
Cannot open fileFilename=/home/cms-jovyan/.rnd
Function: 
Using configuration file /home/cms-jovyan/.glite/vomses
Using configuration file /usr/local/etc/vomses
Segmentation fault (core dumped)
[cms-jovyan@jupyter-oksana-2eshadura-40cern-2ech ~]$ ls -la /usr/local/etc/vomses
ls: cannot access '/usr/local/etc/vomses': No such file or directory
```