### PR TITLE
Update coffea pre-release to rc2 and uproot

### DIFF
--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -62,7 +62,7 @@ dependencies:
   #- coffea=2025.3.0
   - rucio-clients
   - pip:
-    - coffea==2025.5.0.rc1
+    - coffea==2025.5.0.rc2
     - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -35,7 +35,7 @@ dependencies:
   - zstandard
     # file formats
   - h5py
-  - uproot
+  - uproot>=5.6.2
     # misc.
   - pytables
   - python-rapidjson

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -33,7 +33,7 @@ dependencies:
   - zstandard
     # file formats
   - h5py
-  - uproot
+  - uproot>=5.6.2
     # misc.
   - pytables
   - python-rapidjson

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -50,6 +50,6 @@ dependencies:
   #- coffea=2025.3.0
   - rucio-clients
   - pip:
-    - coffea==2025.5.0.rc1
+    - coffea==2025.5.0.rc2
     - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -61,7 +61,7 @@ dependencies:
   #- coffea=2025.3.0
   - rucio-clients
   - pip:
-    - coffea==2025.5.0.rc1
+    - coffea==2025.5.0.rc2
     - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -35,7 +35,7 @@ dependencies:
   - zstandard
     # file formats
   - h5py
-  - uproot
+  - uproot>=5.6.2
     # misc.
   - pytables
   - python-rapidjson


### PR DESCRIPTION
Updating the coffea rc that now includes a big deprecation message for the breaking API change in nanoevents.

This also waits for https://github.com/scikit-hep/uproot5/pull/1436 and an uproot release which is critical fix for executing over files through xrootd. Just waiting for it so that we can build the image once and not twice.