### PR TITLE
Update Coffea version to 2025.3.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2025.5.0.rc2"
+  release: "2025.3.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.26"
 

--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -63,7 +63,7 @@ dependencies:
   - rucio-clients
   - fastjet
   - pip:
-    - coffea==2025.5.0.rc2
+    - coffea=2025.3.0
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python
     - onnxruntime

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -51,5 +51,5 @@ dependencies:
   - rucio-clients
   - fastjet
   - pip:
-    - coffea==2025.5.0.rc2
+    - coffea=2025.3.0
     - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -62,7 +62,7 @@ dependencies:
   - rucio-clients
   - fastjet
   - pip:
-    - coffea==2025.5.0.rc2
+    - coffea=2025.3.0
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python
     - onnxruntime


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.3.0`.