### PR TITLE
build: use now-available conda fastjet

### DIFF
--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -61,9 +61,9 @@ dependencies:
   #- coffea=2025.3.0
   #- coffea=2025.3.0
   - rucio-clients
+  - fastjet
   - pip:
     - coffea==2025.5.0.rc2
-    - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python
     - onnxruntime

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -49,7 +49,7 @@ dependencies:
   - pip
   #- coffea=2025.3.0
   - rucio-clients
+  - fastjet
   - pip:
     - coffea==2025.5.0.rc2
-    - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -60,9 +60,9 @@ dependencies:
   - pytorch-spline-conv
   #- coffea=2025.3.0
   - rucio-clients
+  - fastjet
   - pip:
     - coffea==2025.5.0.rc2
-    - fastjet # to be added to conda-forge: https://github.com/scikit-hep/fastjet/issues/133
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python
     - onnxruntime


### PR DESCRIPTION
We should, from now on, have consistently updated versions of fastjet for all architectures on conda.

Updating environment to reflect that.

@oshadura 