### PR TITLE
Move pytorch to pip installation

### DIFF
--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -50,7 +50,6 @@ dependencies:
   - hist
     # ML
   #- xgboost
-  - pytorch
   - torch-scatter
   - pip
     # pyg
@@ -67,3 +66,4 @@ dependencies:
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python
     - onnxruntime
     - fsspec-xrootd
+    - torch


### PR DESCRIPTION
Addresses #89 

I am only proposing this change for environment.yaml for now, but I am happy to add it to environment-aarch64.yaml if that fits the purpose of that image set. Thanks!