### PR TITLE
Update Coffea version to 2025.7.0

### DIFF
--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -58,11 +58,11 @@ dependencies:
   ##- pytorch-cluster # no aarch64 support
   ##- pytorch-sparse # no aarch64 support
   ##- pytorch-spline-conv # no aarch64 support
-  #- coffea=2025.3.0
-  #- coffea=2025.3.0
+  #- coffea=2025.7.0
+  #- coffea=2025.7.0
   - rucio-clients
   - fastjet
-  - coffea==2025.7.0
+  - coffea=2025.7.0
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -59,9 +59,9 @@ dependencies:
   - pytorch-cluster
   - pytorch-sparse
   - pytorch-spline-conv
-  #- coffea=2025.3.0
+  #- coffea=2025.7.0
   - rucio-clients
-  - coffea==2025.7.0
+  - coffea=2025.7.0
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,9 +47,9 @@ dependencies:
   - vector
   - hist
   - pip
-  #- coffea=2025.3.0
+  #- coffea=2025.7.0
   - rucio-clients
   - fastjet
-  - coffea==2025.7.0
+  - coffea=2025.7.0
   - pip:
     - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -58,10 +58,10 @@ dependencies:
   - pytorch-cluster
   - pytorch-sparse
   - pytorch-spline-conv
-  #- coffea=2025.3.0
+  #- coffea=2025.7.0
   - rucio-clients
   - fastjet
-  - coffea==2025.7.0
+  - coffea=2025.7.0
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.7.0`.