### PR TITLE
Update Coffea version to 2025.7.1

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2025.7.0"
+  release: "2025.7.1"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.26"
 

--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -58,11 +58,11 @@ dependencies:
   ##- pytorch-cluster # no aarch64 support
   ##- pytorch-sparse # no aarch64 support
   ##- pytorch-spline-conv # no aarch64 support
-  #- coffea=2025.7.0
-  #- coffea=2025.7.0
+  #- coffea=2025.7.1
+  #- coffea=2025.7.1
   - rucio-clients
   - fastjet
-  - coffea=2025.7.0
+  - coffea=2025.7.1
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -59,9 +59,9 @@ dependencies:
   - pytorch-cluster
   - pytorch-sparse
   - pytorch-spline-conv
-  #- coffea=2025.7.0
+  #- coffea=2025.7.1
   - rucio-clients
-  - coffea=2025.7.0
+  - coffea=2025.7.1
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,9 +47,9 @@ dependencies:
   - vector
   - hist
   - pip
-  #- coffea=2025.7.0
+  #- coffea=2025.7.1
   - rucio-clients
   - fastjet
-  - coffea=2025.7.0
+  - coffea=2025.7.1
   - pip:
     - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -58,10 +58,10 @@ dependencies:
   - pytorch-cluster
   - pytorch-sparse
   - pytorch-spline-conv
-  #- coffea=2025.7.0
+  #- coffea=2025.7.1
   - rucio-clients
   - fastjet
-  - coffea=2025.7.0
+  - coffea=2025.7.1
   - pip:
     - tritonclient[all]
     - ai-edge-litert-nightly # ai-edge-litert as replacement of tflite is still not available for python


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.7.1`.