### PR TITLE
Update Coffea version to 2025.10.1

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2025.10.0"
+  release: "2025.10.1"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.30"
 

--- a/coffea-dask/environment-aarch64.yaml
+++ b/coffea-dask/environment-aarch64.yaml
@@ -60,7 +60,7 @@ dependencies:
   ##- pytorch-spline-conv # no aarch64 support
   - rucio-clients
   - fastjet
-  - coffea=2025.10.0
+  - coffea=2025.10.1
   - tritonclient[all]
   - onnxruntime
   - fsspec-xrootd

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -60,7 +60,7 @@ dependencies:
   - pytorch-sparse
   - pytorch-spline-conv
   - rucio-clients
-  - coffea=2025.10.0
+  - coffea=2025.10.1
   - onnxruntime
   - fsspec-xrootd
   - pip:

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,5 +47,5 @@ dependencies:
   - pip
   - rucio-clients
   - fastjet
-  - coffea=2025.10.0
+  - coffea=2025.10.1
   - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -58,7 +58,7 @@ dependencies:
   - pytorch-spline-conv
   - rucio-clients
   - fastjet
-  - coffea=2025.10.0
+  - coffea=2025.10.1
   - onnxruntime
   - fsspec-xrootd
   - pip:


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2025.10.1`.