### PR TITLE
Update Coffea version to 2026.5.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.12"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2026.4.0"
+  release: "2026.5.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.30"
 

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -60,7 +60,7 @@ dependencies:
   - pytorch-sparse
   - pytorch-spline-conv
   - rucio-clients
-  - coffea=2026.4.0
+  - coffea=2026.5.0
   - onnxruntime
   - fsspec-xrootd
   - tritonclient

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,5 +47,5 @@ dependencies:
   - pip
   - rucio-clients
   - fastjet
-  - coffea=2026.4.0
+  - coffea=2026.5.0
   - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -58,7 +58,7 @@ dependencies:
   - pytorch-spline-conv
   - rucio-clients
   - fastjet
-  - coffea=2026.4.0
+  - coffea=2026.5.0
   - onnxruntime
   - fsspec-xrootd
   - tritonclient


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `2026.5.0`.