### PR TITLE
Update environments regarding python versions, pytorch related packages, and triton client

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -14,7 +14,7 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
   # Update each time there is added latest python: it will be used for `latest` tag
-  python_latest: "3.12"
+  python_latest: "3.13"
   python_latestv0: "3.10"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
   release: "2026.5.0"
@@ -31,7 +31,7 @@ jobs:
         #registry: [docker.io, hub.opensciencegrid.org]
         registry: [docker.io]
         distro: [almalinux8, almalinux9, almalinux9-noml, almalinux9-eaf]
-        python: ["3.11", "3.12", "3.13"]
+        python: ["3.10", "3.12", "3.13"]
         exclude:
           - image_dir: coffea-base
             distro: almalinux9-noml
@@ -42,7 +42,7 @@ jobs:
           - image_dir: coffea-base
             python: 3.13
           - image_dir: coffea-dask
-            python: 3.11
+            python: 3.10
     name: ${{ matrix.image_dir }}-${{ matrix.distro }}-${{ matrix.python }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -19,7 +19,7 @@ env:
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
   release: "2026.5.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
-  releasev0: "0.7.30"
+  releasev0: "0.7.31"
 
 jobs:
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -31,20 +31,20 @@ jobs:
         #registry: [docker.io, hub.opensciencegrid.org]
         registry: [docker.io]
         distro: [almalinux8, almalinux9, almalinux9-noml, almalinux9-eaf]
-        #python: ["3.10", "3.11", "3.12"]
-        ## Disabling python 3.11 with error:
-        # Out of memory allocating 18446744071562067991*4 bytes!
-        ## Disabling python 3.10 because of timeout errors during build
-        python: ["3.12"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
         exclude:
           - image_dir: coffea-base
             distro: almalinux9-noml
           - image_dir: coffea-base
             distro: almalinux9-eaf
           - image_dir: coffea-base
-            python: 3.11
-          - image_dir: coffea-base
             python: 3.12
+          - image_dir: coffea-base
+            python: 3.13
+          - image_dir: coffea-base
+            python: 3.14
+          - image_dir: coffea-dask
+            python: 3.11
     name: ${{ matrix.image_dir }}-${{ matrix.distro }}-${{ matrix.python }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -15,7 +15,7 @@ env:
   GITHUB_REF: ${{ github.ref }}
   # Update each time there is added latest python: it will be used for `latest` tag
   python_latest: "3.13"
-  python_latestv0: "3.10"
+  python_latestv0: "3.11"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
   release: "2026.5.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
@@ -31,7 +31,7 @@ jobs:
         #registry: [docker.io, hub.opensciencegrid.org]
         registry: [docker.io]
         distro: [almalinux8, almalinux9, almalinux9-noml, almalinux9-eaf]
-        python: ["3.10", "3.12", "3.13"]
+        python: ["3.11", "3.12", "3.13"]
         exclude:
           - image_dir: coffea-base
             distro: almalinux9-noml
@@ -42,7 +42,7 @@ jobs:
           - image_dir: coffea-base
             python: 3.13
           - image_dir: coffea-dask
-            python: 3.10
+            python: 3.11
     name: ${{ matrix.image_dir }}-${{ matrix.distro }}-${{ matrix.python }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -31,7 +31,7 @@ jobs:
         #registry: [docker.io, hub.opensciencegrid.org]
         registry: [docker.io]
         distro: [almalinux8, almalinux9, almalinux9-noml, almalinux9-eaf]
-        python: ["3.11", "3.12", "3.13", "3.14"]
+        python: ["3.11", "3.12", "3.13"]
         exclude:
           - image_dir: coffea-base
             distro: almalinux9-noml
@@ -41,8 +41,6 @@ jobs:
             python: 3.12
           - image_dir: coffea-base
             python: 3.13
-          - image_dir: coffea-base
-            python: 3.14
           - image_dir: coffea-dask
             python: 3.11
     name: ${{ matrix.image_dir }}-${{ matrix.distro }}-${{ matrix.python }}

--- a/coffea-base/Dockerfile.almalinux8
+++ b/coffea-base/Dockerfile.almalinux8
@@ -13,7 +13,7 @@ RUN dnf install -y epel-release && \
     dnf clean all
 
 # Download and install Miniforge
-RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-base/Dockerfile.almalinux8
+++ b/coffea-base/Dockerfile.almalinux8
@@ -21,12 +21,11 @@ RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Mini
     echo ". /usr/local/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc && \
     echo ". /usr/local/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
 
-COPY  environment.yaml requirements.txt  /
+COPY  environment.yaml /
 
 RUN export G_SLICE=always-malloc \
     && mamba install -y python=${PYTHON_VERSION} \
     && CONDA_OVERRIDE_ARCHSPEC=x86_64 mamba env update --file /environment.yaml \
-    && pip install --no-cache-dir -r /requirements.txt \
     && mamba clean -tipy \
     && find /usr/local -type f -name '*.a' -delete \
     && find /usr/local -type f -name '*.pyc' -delete \

--- a/coffea-base/Dockerfile.almalinux9
+++ b/coffea-base/Dockerfile.almalinux9
@@ -21,12 +21,11 @@ RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Mini
     echo ". /usr/local/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc && \
     echo ". /usr/local/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
 
-COPY environment.yaml requirements.txt /
+COPY environment.yaml /
 
 RUN export G_SLICE=always-malloc \
     && mamba install -y python=${PYTHON_VERSION} \
     && CONDA_OVERRIDE_ARCHSPEC=x86_64 mamba env update --file /environment.yaml \
-    && pip install --no-cache-dir -r /requirements.txt \
     && mamba clean -tipy \
     && find /usr/local -type f -name '*.a' -delete \
     && find /usr/local -type f -name '*.pyc' -delete \

--- a/coffea-base/Dockerfile.almalinux9
+++ b/coffea-base/Dockerfile.almalinux9
@@ -13,7 +13,7 @@ RUN dnf install -y epel-release && \
     dnf clean all
 
 # Download and install Miniforge
-RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -1,8 +1,6 @@
 name: base
 channels:
   - conda-forge
-  - pyg
-  - pytorch
 dependencies:
   # python version specified in Dockerfile
   - gxx
@@ -25,7 +23,7 @@ dependencies:
   - ndcctools
     # core scipy
     #- nomkl # no Intel math kernel library, reduces image size
-  - numpy
+  - numpy<2
   - scipy
   - pandas
     # compression
@@ -48,11 +46,6 @@ dependencies:
     # ML
   - xgboost
   - pytorch
-  - torch-scatter
   - pip
   - rucio-clients
-    # pyg
-  - pyg
-  - pytorch-cluster
-  - pytorch-sparse
-  - pytorch-spline-conv
+  - pytorch_geometric

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # python version specified in Dockerfile
+  - setuptools<=71
   - gxx
   - voms # x509 proxy system
   - ca-policy-lcg # WLCG trusted CAs
@@ -49,3 +50,9 @@ dependencies:
   - pip
   - rucio-clients
   - pytorch_geometric
+  - onnxruntime
+  - pip:
+    - awkward == 1.10.5
+    - coffea == 0.7.31
+    - fastjet == 3.4.0.1 # LAST VERSION working with awkward1
+    - tritonclient[grpc,http]

--- a/coffea-base/environment.yaml
+++ b/coffea-base/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - voms # x509 proxy system
   - ca-policy-lcg # WLCG trusted CAs
   - xrootd
-  - htcondor=24.1.1 # pin HTCondor for LPC https://github.com/CoffeaTeam/lpcjobqueue/issues/38
+  - htcondor
   - curl
     # jupyter-related
   - jupyterlab

--- a/coffea-base/requirements.txt
+++ b/coffea-base/requirements.txt
@@ -1,6 +1,0 @@
-coffea == 0.7.31
-awkward == 1.10.5
-setuptools <= 71
-fastjet == 3.4.0.1 # LAST VERSION working with awkward1
-tritonclient[all]
-onnxruntime

--- a/coffea-base/requirements.txt
+++ b/coffea-base/requirements.txt
@@ -1,7 +1,6 @@
-coffea == 0.7.30
+coffea == 0.7.31
 awkward == 1.10.5
 setuptools <= 71
 fastjet == 3.4.0.1 # LAST VERSION working with awkward1
 tritonclient[all]
-tflite-runtime == 2.14.0
 onnxruntime

--- a/coffea-dask/Dockerfile.almalinux8
+++ b/coffea-dask/Dockerfile.almalinux8
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux8
+++ b/coffea-dask/Dockerfile.almalinux8
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9
+++ b/coffea-dask/Dockerfile.almalinux9
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9
+++ b/coffea-dask/Dockerfile.almalinux9
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9-eaf
+++ b/coffea-dask/Dockerfile.almalinux9-eaf
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9-eaf
+++ b/coffea-dask/Dockerfile.almalinux9-eaf
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9-noml
+++ b/coffea-dask/Dockerfile.almalinux9-noml
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/Dockerfile.almalinux9-noml
+++ b/coffea-dask/Dockerfile.almalinux9-noml
@@ -12,7 +12,7 @@ RUN dnf install -y epel-release && \
     dnf install -y wget bzip2 ca-certificates git wget libgfortran which zsh emacs vim htop man man-pages && \
     dnf clean all
 
-RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+RUN wget "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
     bash /tmp/miniforge.sh -bfp /usr/local && \
     rm /tmp/miniforge.sh && \
     conda clean --tarballs --index-cache --packages --yes && \

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -7,9 +7,7 @@ dependencies:
   - voms # x509 proxy system
   - ca-policy-lcg # WLCG trusted CAs
   - xrootd
-  # we have issues with conflicting openssl version and htcondor 10.8.0 version is last one
-  # which we able to resolve in this environment.yaml
-  - htcondor=24.1.1 # pin HTCondor for LPC https://github.com/CoffeaTeam/lpcjobqueue/issues/38
+  - htcondor
   - curl
     # jupyter-related
   - jupyterlab

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -56,5 +56,5 @@ dependencies:
   - coffea=2026.5.0
   - onnxruntime
   - fsspec-xrootd
-  - tritonclient
-  - tritonclient-grpc
+  - pip:
+    - tritonclient[grpc,http]

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -1,8 +1,6 @@
 name: base
 channels:
   - conda-forge
-  - pyg
-  - pytorch
 dependencies:
   # python version specified in Dockerfile
   #- gxx
@@ -26,7 +24,7 @@ dependencies:
   - ndcctools
     # core scipy
     #- nomkl # no Intel math kernel library, reduces image size
-  - numpy
+  - numpy>=2
   - scipy
   - pandas
     # compression
@@ -52,17 +50,11 @@ dependencies:
     # ML
   - xgboost
   - pytorch
-  - torch-scatter
+  - pytorch_geometric
   - pip
-    # pyg
-  - pyg
-  - pytorch-cluster
-  - pytorch-sparse
-  - pytorch-spline-conv
   - rucio-clients
   - coffea=2026.5.0
   - onnxruntime
   - fsspec-xrootd
   - tritonclient
   - tritonclient-grpc
-

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -7,7 +7,7 @@ dependencies:
   - voms # x509 proxy system
   - ca-policy-lcg # WLCG trusted CAs
   - xrootd
-  - htcondor=24.1.1 # pin HTCondor for LPC https://github.com/CoffeaTeam/lpcjobqueue/issues/38
+  - htcondor
   - curl
     # jupyter-related
   - jupyterlab

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -22,7 +22,7 @@ dependencies:
   - ndcctools
     # core scipy
     #- nomkl # no Intel math kernel library, reduces image size
-  - numpy
+  - numpy>=2
   - scipy
   - pandas
     # compression

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
   - voms # x509 proxy system
   - ca-policy-lcg # WLCG trusted CAs
   - xrootd
-  - htcondor=24.1.1 # pin HTCondor for LPC https://github.com/CoffeaTeam/lpcjobqueue/issues/38
+  - htcondor
   - curl
     # jupyter-related
   - jupyterlab

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -1,8 +1,6 @@
 name: base
 channels:
   - conda-forge
-  - pyg
-  - pytorch
 dependencies:
   # python version specified in Dockerfile
   #- gxx
@@ -24,7 +22,7 @@ dependencies:
   - ndcctools
     # core scipy
     #- nomkl # no Intel math kernel library, reduces image size
-  - numpy
+  - numpy>=2
   - scipy
   - pandas
     # compression
@@ -49,13 +47,8 @@ dependencies:
     # ML
   - xgboost
   - pytorch
-  - torch-scatter
+  - pytorch_geometric
   - pip
-    # pyg
-  - pyg
-  - pytorch-cluster
-  - pytorch-sparse
-  - pytorch-spline-conv
   - rucio-clients
   - fastjet
   - coffea=2026.5.0

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -54,5 +54,5 @@ dependencies:
   - coffea=2026.5.0
   - onnxruntime
   - fsspec-xrootd
-  - tritonclient
-  - tritonclient-grpc
+  - pip:
+    - tritonclient[grpc,http]


### PR DESCRIPTION
Coffea 0.7 is now python 3.11 and CalVer is 3.12 and 3.13.
Removing unmaintained pytorch related channels and packages.
Moving tritonclient to pypi as the conda-forge one pins numpy < 2.
Small overall refactoring.

Let's see if we can build this.