### PR TITLE
Revert "Update Coffea version to 2026.5.0"

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -17,7 +17,7 @@ env:
   python_latest: "3.13"
   python_latestv0: "3.11"
   # For coffea 2024.x.x we have conda release, github CI bot will detect new version and open PR with changes
-  release: "2026.5.0"
+  release: "2026.4.0"
   # For coffea 0.7.23 we dont have conda release, please update it manually, as well in coffea-base/environment.yaml
   releasev0: "0.7.31"
 

--- a/coffea-dask/environment-eaf.yaml
+++ b/coffea-dask/environment-eaf.yaml
@@ -51,7 +51,7 @@ dependencies:
   - pytorch_geometric
   - pip
   - rucio-clients
-  - coffea=2026.5.0
+  - coffea=2026.4.0
   - onnxruntime
   - fsspec-xrootd
   - pip:

--- a/coffea-dask/environment-noml.yaml
+++ b/coffea-dask/environment-noml.yaml
@@ -47,5 +47,5 @@ dependencies:
   - pip
   - rucio-clients
   - fastjet
-  - coffea=2026.5.0
+  - coffea=2026.4.0
   - fsspec-xrootd

--- a/coffea-dask/environment.yaml
+++ b/coffea-dask/environment.yaml
@@ -51,7 +51,7 @@ dependencies:
   - pip
   - rucio-clients
   - fastjet
-  - coffea=2026.5.0
+  - coffea=2026.4.0
   - onnxruntime
   - fsspec-xrootd
   - pip:


### PR DESCRIPTION
Reverts CoffeaTeam/af-images#131

We are rebuilding latest tag with improvements from https://github.com/CoffeaTeam/af-images/pull/133